### PR TITLE
Add cli component

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -13,6 +13,7 @@ Build-Depends: cmake,
                libignition-math6-eigen3-dev,
                libignition-plugin-dev,
                libignition-utils1-dev,
+               libignition-utils1-cli-dev,
                libdart6-dev (<< 6.10.0) | libdart-dev (>> 6.9.0),
                libdart6-collision-ode-dev (<< 6.10.0) | libdart-collision-ode-dev (>> 6.9.0),
                libdart6-external-ikfast-dev (<< 6.10.0) | libdart-external-ikfast-dev (>> 6.9.0),
@@ -32,6 +33,7 @@ Depends: libignition-cmake2-dev (>= 2.1.0),
          libignition-plugin-dev,
          libignition-physics4 (= ${binary:Version}),
          libignition-utils1-dev,
+         libignition-utils1-cli-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Physics classes and functions for robot apps - Development files

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -13,6 +13,7 @@ Build-Depends: cmake,
                libignition-math6-eigen3-dev,
                libignition-plugin-dev (>= 1.1.0),
                libignition-utils1-dev,
+               libignition-utils1-cli-dev,
 # dart without major version number to get versions coming from Debian
                libdart6-dev (<< 6.10.0) | libdart-dev (<< 6.10.0),
                libdart6-collision-ode-dev (<< 6.10.0) | libdart-collision-ode-dev (<< 6.10.0),
@@ -33,6 +34,7 @@ Depends: libignition-cmake2-dev (>= 2.1.0),
          libignition-plugin-dev (>= 1.1.0),
          libignition-physics4 (= ${binary:Version}),
          libignition-utils1-dev,
+         libignition-utils1-cli-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Physics classes and functions for robot apps - Development files


### PR DESCRIPTION
debbuilder is broken:

https://build.osrfoundation.org/job/ign-physics4-debbuilder/203/consoleFull

```
-- BUILD ERRORS: These must be resolved before compiling.
-- 	Missing: ignition-utils1 (Components: cli)
-- END BUILD ERRORS
```

Part of https://github.com/ignition-tooling/release-tools/issues/406