### PR TITLE
Only build depend on libignition-utils1-cli-dev

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -33,7 +33,6 @@ Depends: libignition-cmake2-dev (>= 2.1.0),
          libignition-plugin-dev,
          libignition-physics4 (= ${binary:Version}),
          libignition-utils1-dev,
-         libignition-utils1-cli-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Physics classes and functions for robot apps - Development files

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -34,7 +34,6 @@ Depends: libignition-cmake2-dev (>= 2.1.0),
          libignition-plugin-dev (>= 1.1.0),
          libignition-physics4 (= ${binary:Version}),
          libignition-utils1-dev,
-         libignition-utils1-cli-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Physics classes and functions for robot apps - Development files


### PR DESCRIPTION
The cli component of ign-utils1 is used for building executables, but it not needed as a run-time dependency.

Test build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-physics4-debbuilder&build=221)](https://build.osrfoundation.org/job/ign-physics4-debbuilder/221/) https://build.osrfoundation.org/job/ign-physics4-debbuilder/221/