### PR TITLE
Update dart-bullet dependency for focal

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -102,7 +102,7 @@ Depends: libignition-physics4-core-dev,
          libdart6-utils-dev (<< 6.10.0) | libdart-utils-dev (>> 6.9.0),
          libdart6-external-odelcpsolver-dev (<< 6.10.0) | libdart-external-odelcpsolver-dev (>> 6.9.0),
          libdart6-external-ikfast-dev (<< 6.10.0) | libdart-external-ikfast-dev (>> 6.9.0),
-         libdart6-collision-bullet-dev (<< 6.10.0) | libdart-collision-bullet-dev (>> 6.0.0),
+         libdart6-collision-bullet-dev (<< 6.10.0) | libdart-collision-bullet-dev (>> 6.9.0),
          libsdformat11-dev,
          libignition-physics4-dartsim (= ${binary:Version}),
          ${misc:Depends}


### PR DESCRIPTION
Related to https://github.com/ignitionrobotics/ign-physics/pull/239#issuecomment-806400609

Looking at the latest nightly build for `ign-physics4` (which failed: https://build.osrfoundation.org/job/ign-physics4-debbuilder/253/), I noticed that there was a potential version issue with `collision-bullet`. The errors below indicate that we need at least version `6.9`, but the current Debian metadata for Focal appears to list the minimum version as `6.0`. I have bumped the minimum required version to `6.9` in this PR (hopefully this is the right fix).

```
-- Could NOT find DART (missing: collision-bullet) (Required is at least version "6.9")
CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:188 (find_package):
  Found package configuration file:

    /usr/share/dart/cmake/DARTConfig.cmake

  but it set DART_FOUND to FALSE so package "DART" is considered to be NOT
  FOUND.
Call Stack (most recent call first):
  CMakeLists.txt:69 (ign_find_package)


-- Looking for DART - not found

-- -------------------------------------------

-- BUILD WARNINGS
-- 	Cannot build component [dartsim] - Missing: DART (Components: collision-bullet, collision-ode, utils, utils-urdf)
-- END BUILD WARNINGS
```

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>